### PR TITLE
Added Modal component + example usage

### DIFF
--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -1,0 +1,56 @@
+import { createPortal } from 'react-dom';
+import { useModalFunctionality } from './utils';
+import styles from './styles.module.css';
+
+type ModalBaseProps = {
+  children: React.ReactNode;
+  onClose?: (x: React.MouseEvent) => void;
+};
+
+type OptionalProps = {
+  [K in Exclude<
+    keyof JSX.IntrinsicElements['div'],
+    keyof ModalBaseProps
+  >]?: JSX.IntrinsicElements['div'][K];
+};
+
+type ModalProps = ModalBaseProps & OptionalProps;
+
+const Modal = ({
+  children,
+  onClose,
+  className,
+
+  ...rest
+}: ModalProps) => {
+  useModalFunctionality();
+
+  return (
+    <>
+      {createPortal(
+        <div className={styles['modalOuter']}>
+          <div
+            role="dialog"
+            aria-modal="true"
+            {...rest}
+            className={`${className} ${styles['modalInner']}`}
+          >
+            {children}
+            {onClose && (
+              <button
+                aria-label="close"
+                className={styles['closeButton']}
+                onClick={(e) => onClose?.(e)}
+              >
+                &times;
+              </button>
+            )}
+          </div>
+        </div>,
+        document.getElementById('contra_modal_container') as HTMLElement
+      )}
+    </>
+  );
+};
+
+export default Modal;

--- a/frontend/src/components/Modal/index.tsx
+++ b/frontend/src/components/Modal/index.tsx
@@ -1,0 +1,3 @@
+import Modal from './Modal';
+export default Modal;
+export * from './Modal';

--- a/frontend/src/components/Modal/styles.module.css
+++ b/frontend/src/components/Modal/styles.module.css
@@ -1,0 +1,37 @@
+.modalOuter {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modalInner {
+  position: relative;
+
+  padding: 20px;
+  background: white;
+  min-width: 150px;
+  max-width: 100px;
+}
+
+.closeButton {
+  position: absolute;
+  top: 2px;
+  right: 7px;
+  
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  
+  font-size: 25px;
+  font-weight: 900;
+  color: black;
+}

--- a/frontend/src/components/Modal/utils.ts
+++ b/frontend/src/components/Modal/utils.ts
@@ -1,0 +1,86 @@
+import { useEffect } from 'react';
+
+let count = 0;
+
+const focusableElementsSelector =
+  'a[href], button, textarea, input, select, details, [tabindex]:not([tabindex="-1"])';
+
+function getTopModal() {
+  const container = document.getElementById(
+    'contra_modal_container'
+  ) as HTMLElement;
+  if (container === null) throw Error('No #contra_modal_container in DOM');
+
+  const modals = container.childNodes;
+  if (!modals || modals.length === 0) return null;
+  const topModal = modals[modals.length - 1];
+
+  return topModal as HTMLElement;
+}
+
+function getFocusableElements(element: HTMLElement | null) {
+  if (!element) return [];
+
+  return Array.from(element.querySelectorAll(focusableElementsSelector)).filter(
+    (el) => !el.hasAttribute('disabled') && !el.getAttribute('aria-hidden')
+  );
+}
+
+function keyDownListener(e: KeyboardEvent) {
+  if (count === 0 || e.key !== 'Tab') return;
+
+  const topModal = getTopModal();
+  const focusableElements = getFocusableElements(topModal);
+
+  const first = focusableElements[0] as HTMLElement;
+  const last = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+  if (e.shiftKey && document.activeElement === first) {
+    last?.focus();
+    e.preventDefault();
+  } else if (
+    (!e.shiftKey && document.activeElement === last) ||
+    !topModal?.contains(document.activeElement)
+  ) {
+    first?.focus();
+    e.preventDefault();
+  }
+}
+
+export function useModalFunctionality() {
+  useEffect(() => {
+    count++;
+
+    const isFirst = count === 1;
+    if (isFirst) {
+      document.documentElement.classList.add('noscroll' as string);
+      document.getElementById('__next')?.setAttribute('aria-hidden', 'true');
+      window.addEventListener('keydown', keyDownListener);
+    }
+
+    // If something outside the modal is focused
+    if (!getTopModal()?.contains(document.activeElement)) {
+      // remove focus entirely so that the first focusable element in the modal is selected the next time the user presses tab
+      (document.activeElement as HTMLElement)?.blur();
+
+      /*
+        // Alternative option: focus the first element in the modal
+        const firstFocusableElement = getFocusableElements(getTopModal())[0];
+        if (firstFocusableElement instanceof HTMLElement) {
+          firstFocusableElement.focus();
+        }
+      */
+    }
+
+    return () => {
+      count--;
+
+      const noModalsLeft = count === 0;
+      if (noModalsLeft) {
+        document.getElementById('__next')?.setAttribute('aria-hidden', 'false');
+        document.documentElement.classList.remove('noscroll' as string);
+        window.removeEventListener('keydown', keyDownListener);
+      }
+    };
+  }, []);
+}

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -1,0 +1,40 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head />
+      <body>
+        <div id="contra_modal_container" />
+        <style>{`
+html {
+  height: 100%;
+}
+
+body {
+  min-height: 100%;
+  width: 100%;
+  margin: 0;
+  overflow-y: scroll;
+}
+
+html.noscroll #contra_modal_container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(47,47,47,0.6);
+  z-index: 999999;
+}
+
+html.noscroll, html.noscroll > body {
+  position: fixed;
+}
+      `}</style>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,8 +1,76 @@
 /* eslint-disable canonical/filename-match-exported */
+
+import Modal from 'components/Modal';
 import { type NextPage } from 'next';
+import { useState } from 'react';
 
 const Index: NextPage = () => {
-  return <h1>Welcome to Contra!</h1>;
+  const [isModal1active, setModal1active] = useState(false);
+  const [isModal2active, setModal2active] = useState(false);
+  const [isModal3active, setModal3active] = useState(false);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'baseline',
+      }}
+    >
+      <h1>Welcome to Contra!</h1>
+      <button onClick={() => setModal1active(true)}>Open Modal 1</button>
+      <button onClick={() => setModal2active(true)}>Open Modal 2</button>
+      <button onClick={() => setModal3active(true)}>
+        Open Modal 3, which has an autofocus attribute
+      </button>
+      <button
+        onClick={() => {
+          setModal1active(true);
+          setTimeout(() => setModal2active(true), 1000);
+        }}
+      >
+        Open Modal 1 and one second later modal 2
+      </button>
+      <button
+        onClick={() => {
+          setModal2active(true);
+          setTimeout(() => setModal1active(true), 1000);
+        }}
+      >
+        Open Modal 2 and one second later modal 1
+      </button>
+      <button
+        onClick={() => {
+          setModal1active(true);
+          setModal2active(true);
+          setModal3active(true);
+        }}
+      >
+        Open all three modals at once
+      </button>
+      {isModal1active && (
+        <Modal onClose={() => setModal1active(false)}>
+          Hi there from modal 1!
+          <button>A</button>
+          <button>B</button>
+        </Modal>
+      )}
+      {isModal2active && (
+        <Modal onClose={() => setModal2active(false)}>
+          Hi there from modal 2!
+          <button>A</button>
+          <button>B</button>
+        </Modal>
+      )}
+      {isModal3active && (
+        <Modal onClose={() => setModal3active(false)}>
+          Hi there from modal 3!
+          <button>A</button>
+          <button autoFocus>B - Autofocus</button>
+        </Modal>
+      )}
+    </div>
+  );
 };
 
 export default Index;


### PR DESCRIPTION
# Changes
* Created a `components` directory and added a `Modal` component in there.
* Added a container div and style definitions to the `_document.tsx` on which the `Modal` component depends.
* Changed the index page to provide some example modal functionality

## Modal component
The `Modal` component is an easy-to-use component that can be rendered anywhere in the React component tree. Because it uses portals, it doesn't matter where in the React component tree it is rendered, it will always render within the `div#contra_modal_container`. If more than one `Modal` component is rendered at a time, the one rendered last will always be on top, regardless of its position in the React component tree.

### Modal component props
* `children`: A React node defining the content of the modal
* `onClose`: An optional function that is run when the X-shaped close button of the modal is pressed. Omitting this argument will not render the close button at all, allowing you to have modals that force the user to interact with them without being able to close them.
* any valid HTMLElement props/attributes: Any props such as `style`, `className`, `ref`, `onMouseEnter`, etc that are passed to the `Modal` component are relayed to the `<div />` that holds the modal content. This makes the component very modular and extensible, allowing a plethora of customizations to a specific modal. If desired, this could also be done for the close button, but I chose not to, as to keep the component simple for the sake of demonstration.

### Closing the modal
Pressing the X-shaped close button doesn't automatically get rid of the modal, it only fires the `onClose` callback. This is intentional, because modals are usually shown as a result of some event, and thus tend to be rendered conditionally depending on some state. As such, I figured that changing said state so the `Modal` is no longer rendered, causing it to unmount, is the most natural way to close them. This also conveniently allows the consumer of the component to programmatically control closing the modal.

## Modal component prerequisites
The `Modal` component requires a small amount of global styling and a container div for the modals to be rendered into. See the added `<style>` tag and the `div#contra_modal_container`. In a client-side rendered React app, this would go into the `.html` file, while in Next.js this goes in the `_document.tsx`. Of course, the container div has some DOM mutations happening to it, but this should be fine, since the `_document.tsx` is only rendered once on the server, and not on the client, and is thus guaranteed to never rerender.

## Examples on the index page
I added a couple of example buttons on the index page to demonstrate stacking and focus management. Check out modal 3 to see the `autofocus` attribute working properly. I'll walk through these in the Loom video as well.

## Accessibility and tab navigation
The Modal uses a custom hook (defined in `src/components/Modal/utils.ts`) that takes care of setting the background, focus management, and tab navigation. Once a modal opens, if focus is on an element outside of the modal, that focus is lost, effectively making the rest of the page inoperable. The next time Tab is pressed, the first element in the modal gains focus. When Tab is pressed repeatedly, focus cycles through only the current modal's elements. Note that the `autofocus` attribute of React still works inside the modal (See example modal 3 on the index page).

# Notes
I assumed visual styling doesn't matter for this test, because it's not part of the list of requirements in the doc. I applied some very basic styling to the modals themselves (background darkening, close button) just for the purposes of demonstration. My main priority was to create a reusable component that was well-written, simple, and easy to use.